### PR TITLE
fix(typing): lowercase package name for adonis instruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "HCAPTCHA_SECRET_KEY": "",
       "HCAPTCHA_SITE_KEY": ""
     },
-    "types": "adonisJS-hcaptcha",
+    "types": "adonisjs-hcaptcha",
     "providers": [
       "adonisJS-hcaptcha"
     ]

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     },
     "types": "adonisjs-hcaptcha",
     "providers": [
-      "adonisJS-hcaptcha"
+      "adonisjs-hcaptcha"
     ]
   }
 }


### PR DESCRIPTION
Hey! 👋🏻 

The `type` property should be filled with the package name, which is lowercase.